### PR TITLE
Make session look for credentials to download warcs

### DIFF
--- a/sourcing/cc_pseudo_crawl/python_scripts/download_warc.py
+++ b/sourcing/cc_pseudo_crawl/python_scripts/download_warc.py
@@ -88,9 +88,7 @@ thread_data = threading.local()
 
 def set_global_session():
     if not hasattr(thread_data, "s3_client"):
-        thread_data.s3_client = boto3.session.Session(region_name="us-east-1").client(
-            "s3", config=Config(signature_version=botocore.UNSIGNED)
-        )
+        thread_data.s3_client = boto3.session.Session(region_name="us-east-1").client("s3")
 
 
 thread_pool = None


### PR DESCRIPTION
Not sure if this PR is the best way to resolve the issue, but we might want to do something about this:

I've found that I can't use this script to successfully download WARCs without this change. This is because, since April 2022, users need to be authenticated to access the data via S3. https://commoncrawl.org/access-the-data/.

Let me know what you think!