### PR TITLE
Improve main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 
 This repository contains all the tools and code used to build the ROOTS dataset produced by the BigScience initiative to train the BLOOM models as well as a reduced version to train the tokenizer.
 
-## [Code for making the Pseudo-Crawl dataset](sourcing/cc_pseudo_crawl)
+## General pipeline for the preparation of the ROOTS dataset
+![diagram_preprocessing_roots](https://user-images.githubusercontent.com/55560583/186378062-2c4691b1-67a8-4fd9-a7c4-a14a98cbc9d1.jpg)
 
-## [Filtering library used to filter OSCAR](preprocessing/training/01b_oscar_cleaning_and_filtering)
+## Key ressources
+### [Code for making the Pseudo-Crawl dataset](sourcing/cc_pseudo_crawl)
 
-## [Code used to run preprocessing pipeline on crowdsourced dataset](preprocessing/training)
+### [Filtering library used to filter OSCAR](preprocessing/training/01b_oscar_cleaning_and_filtering)
 
-## [Code used for the tokenizer](preprocessing/tokenizer)
+### [Code used to run preprocessing pipeline on crowdsourced dataset](preprocessing/training/01a_catalogue_cleaning_and_filtering)
 
-## [Code used for making the analysis and plots for the paper](analysis)
+### [Code used for the tokenizer's training dataset](preprocessing/tokenizer)
+
+### [Code used for making the analysis and plots for the paper](analysis)


### PR DESCRIPTION
I would like to suggest adding the following diagram to the main readme to make the repo easier to understand.
![diagram_preprocessing_roots](https://user-images.githubusercontent.com/55560583/186379169-5e306508-fa63-4e40-b9c3-7e5b12d98242.jpg)

For future, here's the link to the diagram that can be modified: https://drive.google.com/file/d/1bDmFrNi0SaUhLObKX5WWyowfqZiFGByb/view?usp=sharing
